### PR TITLE
crawl for geom_alt prop updates

### DIFF
--- a/data/421/178/347/421178347.geojson
+++ b/data/421/178/347/421178347.geojson
@@ -563,6 +563,9 @@
     },
     "wof:country":"GQ",
     "wof:created":1459009178,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"090e79d8d99d6f3b490df7b0c3af456d",
     "wof:hierarchy":[
         {
@@ -573,7 +576,7 @@
         }
     ],
     "wof:id":421178347,
-    "wof:lastmodified":1566640371,
+    "wof:lastmodified":1582359966,
     "wof:name":"Malabo",
     "wof:parent_id":85671595,
     "wof:placetype":"locality",

--- a/data/856/322/87/85632287.geojson
+++ b/data/856/322/87/85632287.geojson
@@ -1017,6 +1017,11 @@
     },
     "wof:country":"GQ",
     "wof:country_alpha3":"GNQ",
+    "wof:geom_alt":[
+        "naturalearth",
+        "naturalearth-display-terrestrial-zoom6",
+        "meso"
+    ],
     "wof:geomhash":"38a3c81d53a41ca31bc1d6f3aaa60c04",
     "wof:hierarchy":[
         {
@@ -1033,7 +1038,7 @@
         "spa",
         "fra"
     ],
-    "wof:lastmodified":1566640230,
+    "wof:lastmodified":1582359963,
     "wof:name":"Equatorial Guinea",
     "wof:parent_id":102191573,
     "wof:placetype":"country",

--- a/data/856/715/63/85671563.geojson
+++ b/data/856/715/63/85671563.geojson
@@ -283,6 +283,9 @@
         "wk:page":"Annob\u00f3n Province"
     },
     "wof:country":"GQ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"5a01086467825844b1009d79d57a37f6",
     "wof:hierarchy":[
         {
@@ -300,7 +303,7 @@
         "spa",
         "fra"
     ],
-    "wof:lastmodified":1566640229,
+    "wof:lastmodified":1582359963,
     "wof:name":"Annob\u00f3n",
     "wof:parent_id":85632287,
     "wof:placetype":"region",

--- a/data/856/715/65/85671565.geojson
+++ b/data/856/715/65/85671565.geojson
@@ -274,6 +274,9 @@
         "wk:page":"Centro Sur Province"
     },
     "wof:country":"GQ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"7ed071cac5d9048d54976c4077135553",
     "wof:hierarchy":[
         {
@@ -291,7 +294,7 @@
         "spa",
         "fra"
     ],
-    "wof:lastmodified":1566640229,
+    "wof:lastmodified":1582359963,
     "wof:name":"Centro Sur",
     "wof:parent_id":85632287,
     "wof:placetype":"region",

--- a/data/856/715/83/85671583.geojson
+++ b/data/856/715/83/85671583.geojson
@@ -265,6 +265,9 @@
         "wk:page":"Ki\u00e9-Ntem Province"
     },
     "wof:country":"GQ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"7cc5189a7a2c701a89b78ce0631c7873",
     "wof:hierarchy":[
         {
@@ -282,7 +285,7 @@
         "spa",
         "fra"
     ],
-    "wof:lastmodified":1566640229,
+    "wof:lastmodified":1582359963,
     "wof:name":"Ki\u00e9-Ntem",
     "wof:parent_id":85632287,
     "wof:placetype":"region",

--- a/data/856/715/89/85671589.geojson
+++ b/data/856/715/89/85671589.geojson
@@ -272,6 +272,9 @@
         "wk:page":"Litoral Province (Equatorial Guinea)"
     },
     "wof:country":"GQ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a5a8ce6de82aae656e93a48c6a44b138",
     "wof:hierarchy":[
         {
@@ -289,7 +292,7 @@
         "spa",
         "fra"
     ],
-    "wof:lastmodified":1566640228,
+    "wof:lastmodified":1582359963,
     "wof:name":"Litoral",
     "wof:parent_id":85632287,
     "wof:placetype":"region",

--- a/data/856/715/91/85671591.geojson
+++ b/data/856/715/91/85671591.geojson
@@ -257,6 +257,9 @@
         "wk:page":"Wele-Nzas Province"
     },
     "wof:country":"GQ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"7cba9ab5e22e164d7b926575c579266c",
     "wof:hierarchy":[
         {
@@ -274,7 +277,7 @@
         "spa",
         "fra"
     ],
-    "wof:lastmodified":1566640228,
+    "wof:lastmodified":1582359963,
     "wof:name":"Wele-Nz\u00e1s",
     "wof:parent_id":85632287,
     "wof:placetype":"region",

--- a/data/856/715/95/85671595.geojson
+++ b/data/856/715/95/85671595.geojson
@@ -273,6 +273,9 @@
         "wk:page":"Bioko Norte Province"
     },
     "wof:country":"GQ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"6f6d26b45f8f5aae1a4eb96155585ae3",
     "wof:hierarchy":[
         {
@@ -290,7 +293,7 @@
         "spa",
         "fra"
     ],
-    "wof:lastmodified":1566640228,
+    "wof:lastmodified":1582359963,
     "wof:name":"Bioko Norte",
     "wof:parent_id":85632287,
     "wof:placetype":"region",

--- a/data/856/715/99/85671599.geojson
+++ b/data/856/715/99/85671599.geojson
@@ -273,6 +273,9 @@
         "wk:page":"Bioko Sur Province"
     },
     "wof:country":"GQ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"9ad763d581797413b136f27b8e898c16",
     "wof:hierarchy":[
         {
@@ -290,7 +293,7 @@
         "spa",
         "fra"
     ],
-    "wof:lastmodified":1566640229,
+    "wof:lastmodified":1582359963,
     "wof:name":"Bioko Sur",
     "wof:parent_id":85632287,
     "wof:placetype":"region",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1793

This PR:

- Adds a new `wof:geom_alt` property to any "default" WOF record that has an alt file, logic [here](https://github.com/whosonfirst-data/whosonfirst-data/issues/1793#issuecomment-587895012)
- Double checks existing `src:geom_alt` properties to ensure all alt file sources are accounted for in the property list. 

This will not require PIP work to update hierarchies.