### PR TITLE
gq concordances, placetype local, and more

### DIFF
--- a/data/110/878/522/5/1108785225.geojson
+++ b/data/110/878/522/5/1108785225.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.167382,
-    "geom:area_square_m":2069133839.135661,
+    "geom:area_square_m":2069133839.135666,
     "geom:bbox":"10.7098046255,1.07327662265,11.1652356305,1.59642294684",
     "geom:latitude":1.34809,
     "geom:longitude":10.943234,
@@ -101,9 +101,10 @@
     "wof:concordances":{
         "hasc:id":"GQ.WE.AC"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GQ",
     "wof:created":1481835963,
-    "wof:geomhash":"99e945da8466d8b27aec30204a046297",
+    "wof:geomhash":"90e180375c84123fef79c0ff7d923235",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -113,7 +114,7 @@
         }
     ],
     "wof:id":1108785225,
-    "wof:lastmodified":1566640331,
+    "wof:lastmodified":1695886320,
     "wof:name":"Aconibe",
     "wof:parent_id":85671591,
     "wof:placetype":"county",

--- a/data/110/878/522/7/1108785227.geojson
+++ b/data/110/878/522/7/1108785227.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.125599,
-    "geom:area_square_m":1552771649.120675,
+    "geom:area_square_m":1552771649.120678,
     "geom:bbox":"10.2173832269,1.0,10.9761508467,1.23687536501",
     "geom:latitude":1.091989,
     "geom:longitude":10.618826,
@@ -98,9 +98,10 @@
     "wof:concordances":{
         "hasc:id":"GQ.CS.AR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GQ",
     "wof:created":1481835964,
-    "wof:geomhash":"902a58efc8c98995f0715d9041a4aa14",
+    "wof:geomhash":"8824d53ae5c5dd6430d610705877f033",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -110,7 +111,7 @@
         }
     ],
     "wof:id":1108785227,
-    "wof:lastmodified":1566640330,
+    "wof:lastmodified":1695886319,
     "wof:name":"Acurenam",
     "wof:parent_id":85671565,
     "wof:placetype":"county",

--- a/data/110/878/522/9/1108785229.geojson
+++ b/data/110/878/522/9/1108785229.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.091708,
-    "geom:area_square_m":1133441351.922345,
+    "geom:area_square_m":1133441351.922319,
     "geom:bbox":"10.6678333986,1.57476469864,11.0207649898,1.97238382912",
     "geom:latitude":1.770501,
     "geom:longitude":10.839375,
@@ -95,9 +95,10 @@
     "wof:concordances":{
         "hasc:id":"GQ.WE.AK"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GQ",
     "wof:created":1481835965,
-    "wof:geomhash":"1f4a0fbeb7710e4c0a1cb5debbb14d68",
+    "wof:geomhash":"7ba0a121eff571277a27675335efcbab",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -107,7 +108,7 @@
         }
     ],
     "wof:id":1108785229,
-    "wof:lastmodified":1566640330,
+    "wof:lastmodified":1695886320,
     "wof:name":"A\u00f1isoc",
     "wof:parent_id":85671591,
     "wof:placetype":"county",

--- a/data/110/878/523/3/1108785233.geojson
+++ b/data/110/878/523/3/1108785233.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.023415,
-    "geom:area_square_m":288937409.051777,
+    "geom:area_square_m":288937585.59945,
     "geom:bbox":"8.770228,3.528311,8.940444,3.76625",
     "geom:latitude":3.653716,
     "geom:longitude":8.865186,
@@ -80,9 +80,10 @@
     "wof:concordances":{
         "hasc:id":"GQ.BN.BN"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GQ",
     "wof:created":1481835966,
-    "wof:geomhash":"ba829d4deab804a76efda871e0db7c05",
+    "wof:geomhash":"48032554f237474e83e17727e84a949d",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -92,7 +93,7 @@
         }
     ],
     "wof:id":1108785233,
-    "wof:lastmodified":1627522159,
+    "wof:lastmodified":1695886627,
     "wof:name":"Baney",
     "wof:parent_id":85671595,
     "wof:placetype":"county",

--- a/data/110/878/523/5/1108785235.geojson
+++ b/data/110/878/523/5/1108785235.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.092314,
-    "geom:area_square_m":1140827351.371975,
+    "geom:area_square_m":1140827351.372006,
     "geom:bbox":"9.66164646505,1.65866817876,9.9346145266,2.343722105",
     "geom:latitude":1.933392,
     "geom:longitude":9.83393,
@@ -116,9 +116,10 @@
     "wof:concordances":{
         "hasc:id":"GQ.LI.BT"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GQ",
     "wof:created":1481835967,
-    "wof:geomhash":"f3945c2024e5dc5ea4bbe0008e528585",
+    "wof:geomhash":"e24f2b794e9884ed07f5d7a91511aea1",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -128,7 +129,7 @@
         }
     ],
     "wof:id":1108785235,
-    "wof:lastmodified":1566640332,
+    "wof:lastmodified":1695886320,
     "wof:name":"Bata",
     "wof:parent_id":85671589,
     "wof:placetype":"county",

--- a/data/110/878/523/7/1108785237.geojson
+++ b/data/110/878/523/7/1108785237.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.059964,
-    "geom:area_square_m":741103014.742555,
+    "geom:area_square_m":741103455.758593,
     "geom:bbox":"10.529065,1.559594,10.810048,2.021691",
     "geom:latitude":1.792928,
     "geom:longitude":10.656644,
@@ -83,9 +83,10 @@
     "wof:concordances":{
         "hasc:id":"GQ.WE.AY"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GQ",
     "wof:created":1481835968,
-    "wof:geomhash":"42482c1a459014396a5b6410673915d6",
+    "wof:geomhash":"1cbc0c60ed8c6791601de4f5ffc37404",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -95,7 +96,7 @@
         }
     ],
     "wof:id":1108785237,
-    "wof:lastmodified":1627522158,
+    "wof:lastmodified":1695886627,
     "wof:name":"Ayene",
     "wof:parent_id":85671591,
     "wof:placetype":"county",

--- a/data/110/878/523/9/1108785239.geojson
+++ b/data/110/878/523/9/1108785239.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.121564,
-    "geom:area_square_m":1502623189.852629,
+    "geom:area_square_m":1502623045.620923,
     "geom:bbox":"10.063256,1.355545,10.589648,1.740577",
     "geom:latitude":1.52606,
     "geom:longitude":10.329016,
@@ -83,9 +83,10 @@
     "wof:concordances":{
         "hasc:id":"GQ.CS.BG"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GQ",
     "wof:created":1481835969,
-    "wof:geomhash":"6bc658aab1c160115ae479ab15138da0",
+    "wof:geomhash":"f9765ff6486abab34c23ee66c3cd1107",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -95,7 +96,7 @@
         }
     ],
     "wof:id":1108785239,
-    "wof:lastmodified":1627522159,
+    "wof:lastmodified":1695886627,
     "wof:name":"Bicurga",
     "wof:parent_id":85671565,
     "wof:placetype":"county",

--- a/data/110/878/524/1/1108785241.geojson
+++ b/data/110/878/524/1/1108785241.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.094791,
-    "geom:area_square_m":1171763317.675522,
+    "geom:area_square_m":1171762906.904021,
     "geom:bbox":"9.38625,1.210369,10.108944,1.510845",
     "geom:latitude":1.380627,
     "geom:longitude":9.689994,
@@ -80,9 +80,10 @@
     "wof:concordances":{
         "hasc:id":"GQ.LI.BC"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GQ",
     "wof:created":1481835970,
-    "wof:geomhash":"6fbc6526ff40fde471c34ad822ca4ffe",
+    "wof:geomhash":"6a20510dd63b9d58b9e28acf7730d30c",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -92,7 +93,7 @@
         }
     ],
     "wof:id":1108785241,
-    "wof:lastmodified":1627522159,
+    "wof:lastmodified":1695886627,
     "wof:name":"Bitica",
     "wof:parent_id":85671589,
     "wof:placetype":"county",

--- a/data/110/878/524/3/1108785243.geojson
+++ b/data/110/878/524/3/1108785243.geojson
@@ -62,6 +62,7 @@
     "wof:concordances":{
         "hasc:id":"GQ.LI.CO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GQ",
     "wof:created":1481835971,
     "wof:geomhash":"cf1a6ad86daa494edbde532d8757a208",
@@ -74,7 +75,7 @@
         }
     ],
     "wof:id":1108785243,
-    "wof:lastmodified":1694497839,
+    "wof:lastmodified":1695886320,
     "wof:name":"Cogo",
     "wof:parent_id":85671589,
     "wof:placetype":"county",

--- a/data/110/878/524/5/1108785245.geojson
+++ b/data/110/878/524/5/1108785245.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.001304,
-    "geom:area_square_m":16118135.180025,
+    "geom:area_square_m":16118135.180023,
     "geom:bbox":"9.303750038,0.886222243,9.34624958,0.934583306",
     "geom:latitude":0.910125,
     "geom:longitude":9.322483,
@@ -110,9 +110,10 @@
     "wof:concordances":{
         "hasc:id":"GQ.LI.CR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GQ",
     "wof:created":1481835972,
-    "wof:geomhash":"88c0999f72ffa7a603c5aaada61b2a6f",
+    "wof:geomhash":"a3e592d086b611ace059ddc43168e3ec",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -122,7 +123,7 @@
         }
     ],
     "wof:id":1108785245,
-    "wof:lastmodified":1566640332,
+    "wof:lastmodified":1695886320,
     "wof:name":"Corisco",
     "wof:parent_id":85671589,
     "wof:placetype":"county",

--- a/data/110/878/524/7/1108785247.geojson
+++ b/data/110/878/524/7/1108785247.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.06601,
-    "geom:area_square_m":815715814.305305,
+    "geom:area_square_m":815715988.445152,
     "geom:bbox":"10.9939,1.764186,11.3333,2.172222",
     "geom:latitude":2.024844,
     "geom:longitude":11.231404,
@@ -62,9 +62,10 @@
     "wof:concordances":{
         "hasc:id":"GQ.KN.EB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GQ",
     "wof:created":1481835973,
-    "wof:geomhash":"08fc099c790fb8157d3070a53fd9f8da",
+    "wof:geomhash":"046f54212eb972329c2d40511f9fd721",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -74,7 +75,7 @@
         }
     ],
     "wof:id":1108785247,
-    "wof:lastmodified":1627522159,
+    "wof:lastmodified":1695886627,
     "wof:name":"Ebebiyin",
     "wof:parent_id":85671583,
     "wof:placetype":"county",

--- a/data/110/878/525/1/1108785251.geojson
+++ b/data/110/878/525/1/1108785251.geojson
@@ -100,7 +100,7 @@
         }
     ],
     "wof:id":1108785251,
-    "wof:lastmodified":1694497839,
+    "wof:lastmodified":1695886320,
     "wof:name":"Elobey Grande",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/110/878/525/3/1108785253.geojson
+++ b/data/110/878/525/3/1108785253.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.170572,
-    "geom:area_square_m":2108586628.026395,
+    "geom:area_square_m":2108586335.205894,
     "geom:bbox":"10.109432,1.125218,10.770053,1.594032",
     "geom:latitude":1.333636,
     "geom:longitude":10.47841,
@@ -128,9 +128,10 @@
     "wof:concordances":{
         "hasc:id":"GQ.CS.EV"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GQ",
     "wof:created":1481835975,
-    "wof:geomhash":"01f5a9bd5b9dd8a453004286403b38df",
+    "wof:geomhash":"37eb4024d1e73ba27563b973e9ea7def",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -140,7 +141,7 @@
         }
     ],
     "wof:id":1108785253,
-    "wof:lastmodified":1636503072,
+    "wof:lastmodified":1695886089,
     "wof:name":"Evinayong",
     "wof:parent_id":85671565,
     "wof:placetype":"county",

--- a/data/110/878/525/5/1108785255.geojson
+++ b/data/110/878/525/5/1108785255.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.071302,
-    "geom:area_square_m":880107334.933967,
+    "geom:area_square_m":880107537.779179,
     "geom:bbox":"8.419528,3.207917,8.74967,3.614304",
     "geom:latitude":3.396325,
     "geom:longitude":8.584261,
@@ -119,9 +119,10 @@
     "wof:concordances":{
         "hasc:id":"GQ.BS.LU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GQ",
     "wof:created":1481835976,
-    "wof:geomhash":"89de8495ce43e503085f2103ad047171",
+    "wof:geomhash":"2ccfb0fb3b4b45ae1958c7977a54c919",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -131,7 +132,7 @@
         }
     ],
     "wof:id":1108785255,
-    "wof:lastmodified":1636503072,
+    "wof:lastmodified":1695886089,
     "wof:name":"Luba",
     "wof:parent_id":85671599,
     "wof:placetype":"county",

--- a/data/110/878/525/7/1108785257.geojson
+++ b/data/110/878/525/7/1108785257.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.031571,
-    "geom:area_square_m":389583329.872272,
+    "geom:area_square_m":389583329.872288,
     "geom:bbox":"8.60969407825,3.56559361696,8.82642715013,3.787055492",
     "geom:latitude":3.669525,
     "geom:longitude":8.723803,
@@ -395,9 +395,10 @@
     "wof:concordances":{
         "hasc:id":"GQ.BN.ML"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GQ",
     "wof:created":1481835977,
-    "wof:geomhash":"550219440d856732d55830655442861f",
+    "wof:geomhash":"d2bc7cba55ffde99122a65d7f0dcea2c",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -407,7 +408,7 @@
         }
     ],
     "wof:id":1108785257,
-    "wof:lastmodified":1566640330,
+    "wof:lastmodified":1695886320,
     "wof:name":"Malabo",
     "wof:parent_id":85671595,
     "wof:placetype":"county",

--- a/data/110/878/525/9/1108785259.geojson
+++ b/data/110/878/525/9/1108785259.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.095849,
-    "geom:area_square_m":1184750692.464859,
+    "geom:area_square_m":1184750818.527976,
     "geom:bbox":"9.570389,1.467393,10.114125,1.71707",
     "geom:latitude":1.568733,
     "geom:longitude":9.838143,
@@ -134,9 +134,10 @@
     "wof:concordances":{
         "hasc:id":"GQ.LI.MB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GQ",
     "wof:created":1481835978,
-    "wof:geomhash":"ed056405a417e3c23fd38fc9a7cc8bf2",
+    "wof:geomhash":"bd567e6748b8d567403848c853b7c060",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -146,7 +147,7 @@
         }
     ],
     "wof:id":1108785259,
-    "wof:lastmodified":1636503072,
+    "wof:lastmodified":1695886089,
     "wof:name":"Mbini",
     "wof:parent_id":85671589,
     "wof:placetype":"county",

--- a/data/110/878/526/1/1108785261.geojson
+++ b/data/110/878/526/1/1108785261.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.060249,
-    "geom:area_square_m":744565869.230422,
+    "geom:area_square_m":744565830.456458,
     "geom:bbox":"9.912936,1.673729,10.052319,2.202116",
     "geom:latitude":1.943861,
     "geom:longitude":9.976911,
@@ -92,9 +92,10 @@
     "wof:concordances":{
         "hasc:id":"GQ.LI.MC"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GQ",
     "wof:created":1481835979,
-    "wof:geomhash":"fcfc67a89533ce8cfb203943a0f05981",
+    "wof:geomhash":"3e75415e4be1a4fdacb6ef1614127c68",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -104,7 +105,7 @@
         }
     ],
     "wof:id":1108785261,
-    "wof:lastmodified":1627522159,
+    "wof:lastmodified":1695886627,
     "wof:name":"Machinda",
     "wof:parent_id":85671589,
     "wof:placetype":"county",

--- a/data/110/878/526/3/1108785263.geojson
+++ b/data/110/878/526/3/1108785263.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.077497,
-    "geom:area_square_m":957635249.058619,
+    "geom:area_square_m":957634966.769566,
     "geom:bbox":"10.498994,1.93197,11.033429,2.172222",
     "geom:latitude":2.082745,
     "geom:longitude":10.793336,
@@ -62,9 +62,10 @@
     "wof:concordances":{
         "hasc:id":"GQ.KN.MS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GQ",
     "wof:created":1481835980,
-    "wof:geomhash":"7ffd16404cb24b1c6438d949060c120f",
+    "wof:geomhash":"2d082313e069fbe6f27c40fb348260f5",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -74,7 +75,7 @@
         }
     ],
     "wof:id":1108785263,
-    "wof:lastmodified":1627522159,
+    "wof:lastmodified":1695886627,
     "wof:name":"Micomiseng",
     "wof:parent_id":85671583,
     "wof:placetype":"county",

--- a/data/110/878/526/5/1108785265.geojson
+++ b/data/110/878/526/5/1108785265.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.057046,
-    "geom:area_square_m":705105928.298267,
+    "geom:area_square_m":705105898.553879,
     "geom:bbox":"11.075883,1.439151,11.3333,1.808698",
     "geom:latitude":1.622921,
     "geom:longitude":11.239887,
@@ -137,9 +137,10 @@
     "wof:concordances":{
         "hasc:id":"GQ.WE.MG"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GQ",
     "wof:created":1481835982,
-    "wof:geomhash":"a134d9676993872b92947cbc3b7df062",
+    "wof:geomhash":"aa50fb52cf0afee7d27aa489c6a383d4",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -149,7 +150,7 @@
         }
     ],
     "wof:id":1108785265,
-    "wof:lastmodified":1636503072,
+    "wof:lastmodified":1695886089,
     "wof:name":"Mongomo",
     "wof:parent_id":85671591,
     "wof:placetype":"county",

--- a/data/110/878/526/9/1108785269.geojson
+++ b/data/110/878/526/9/1108785269.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.044251,
-    "geom:area_square_m":546950542.781027,
+    "geom:area_square_m":546950405.766417,
     "geom:bbox":"10.9423,1.506673,11.207457,1.774113",
     "geom:latitude":1.649894,
     "geom:longitude":11.066688,
@@ -62,9 +62,10 @@
     "wof:concordances":{
         "hasc:id":"GQ.WE.MM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GQ",
     "wof:created":1481835983,
-    "wof:geomhash":"9e096bde7063154aa33d897a931f095c",
+    "wof:geomhash":"91cc754c2806423e11995862c07a7de3",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -74,7 +75,7 @@
         }
     ],
     "wof:id":1108785269,
-    "wof:lastmodified":1627522159,
+    "wof:lastmodified":1695886627,
     "wof:name":"Mongomoyen",
     "wof:parent_id":85671591,
     "wof:placetype":"county",

--- a/data/110/878/527/1/1108785271.geojson
+++ b/data/110/878/527/1/1108785271.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.164855,
-    "geom:area_square_m":2037365395.087528,
+    "geom:area_square_m":2037365395.087497,
     "geom:bbox":"9.98008530164,1.57687581754,10.3946876993,2.172222",
     "geom:latitude":1.874952,
     "geom:longitude":10.178219,
@@ -83,9 +83,10 @@
     "wof:concordances":{
         "hasc:id":"GQ.CS.NF"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GQ",
     "wof:created":1481835984,
-    "wof:geomhash":"ad708a9c9325e5aeca4e4ccc895736ea",
+    "wof:geomhash":"32cca993db9774bd099329a14c66b668",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -95,7 +96,7 @@
         }
     ],
     "wof:id":1108785271,
-    "wof:lastmodified":1566640329,
+    "wof:lastmodified":1695886319,
     "wof:name":"Niefang",
     "wof:parent_id":85671565,
     "wof:placetype":"county",

--- a/data/110/878/527/3/1108785273.geojson
+++ b/data/110/878/527/3/1108785273.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.089104,
-    "geom:area_square_m":1101158479.63203,
+    "geom:area_square_m":1101158443.061871,
     "geom:bbox":"10.305957,1.674936,10.616356,2.172222",
     "geom:latitude":1.925644,
     "geom:longitude":10.430317,
@@ -92,9 +92,10 @@
     "wof:concordances":{
         "hasc:id":"GQ.CS.NM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GQ",
     "wof:created":1481835985,
-    "wof:geomhash":"49323585220c7e0e364a8676898000b0",
+    "wof:geomhash":"fcb706a6e10b22d7697506cd5f98f33d",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -104,7 +105,7 @@
         }
     ],
     "wof:id":1108785273,
-    "wof:lastmodified":1627522159,
+    "wof:lastmodified":1695886628,
     "wof:name":"Nkimi",
     "wof:parent_id":85671565,
     "wof:placetype":"county",

--- a/data/110/878/527/5/1108785275.geojson
+++ b/data/110/878/527/5/1108785275.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.030933,
-    "geom:area_square_m":382257328.538488,
+    "geom:area_square_m":382257243.102063,
     "geom:bbox":"10.380148,1.91363,10.633254,2.129727",
     "geom:latitude":2.012025,
     "geom:longitude":10.52211,
@@ -62,9 +62,10 @@
     "wof:concordances":{
         "hasc:id":"GQ.KN.NK"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GQ",
     "wof:created":1481835986,
-    "wof:geomhash":"b94633bf22dd7afdf658bb092bd3cdfc",
+    "wof:geomhash":"dbeb940b84910d4b67c83b7922e7afab",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -74,7 +75,7 @@
         }
     ],
     "wof:id":1108785275,
-    "wof:lastmodified":1627522159,
+    "wof:lastmodified":1695886628,
     "wof:name":"Nkue",
     "wof:parent_id":85671583,
     "wof:placetype":"county",

--- a/data/110/878/527/7/1108785277.geojson
+++ b/data/110/878/527/7/1108785277.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.077143,
-    "geom:area_square_m":953350569.4885,
+    "geom:area_square_m":953350675.283953,
     "geom:bbox":"10.921855,1.755108,11.246584,2.118924",
     "geom:latitude":1.922287,
     "geom:longitude":11.078639,
@@ -62,9 +62,10 @@
     "wof:concordances":{
         "hasc:id":"GQ.KN.NN"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GQ",
     "wof:created":1481835987,
-    "wof:geomhash":"673c920f7d71772dae2002269f09aecc",
+    "wof:geomhash":"e93d22834b6325e86d07ca47de727b27",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -74,7 +75,7 @@
         }
     ],
     "wof:id":1108785277,
-    "wof:lastmodified":1627522159,
+    "wof:lastmodified":1695886628,
     "wof:name":"Nsoc Nsomo",
     "wof:parent_id":85671583,
     "wof:placetype":"county",

--- a/data/110/878/527/9/1108785279.geojson
+++ b/data/110/878/527/9/1108785279.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.10958,
-    "geom:area_square_m":1354673346.056099,
+    "geom:area_square_m":1354673082.253248,
     "geom:bbox":"10.962163,1.0,11.3333,1.523501",
     "geom:latitude":1.206683,
     "geom:longitude":11.206574,
@@ -62,9 +62,10 @@
     "wof:concordances":{
         "hasc:id":"GQ.WE.NR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GQ",
     "wof:created":1481835988,
-    "wof:geomhash":"45226148c207e37890936adda58b4f5f",
+    "wof:geomhash":"0a23d42ad4ccd8429601cb925a5395fe",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -74,7 +75,7 @@
         }
     ],
     "wof:id":1108785279,
-    "wof:lastmodified":1627522159,
+    "wof:lastmodified":1695886628,
     "wof:name":"Nsork",
     "wof:parent_id":85671591,
     "wof:placetype":"county",

--- a/data/110/878/528/1/1108785281.geojson
+++ b/data/110/878/528/1/1108785281.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.032271,
-    "geom:area_square_m":398329556.260146,
+    "geom:area_square_m":398329556.260139,
     "geom:bbox":"8.65985234302,3.22983514097,8.857889175,3.58823962727",
     "geom:latitude":3.421991,
     "geom:longitude":8.748029,
@@ -86,9 +86,10 @@
     "wof:concordances":{
         "hasc:id":"GQ.BS.RI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GQ",
     "wof:created":1481835989,
-    "wof:geomhash":"0eca50b68ad53456065d1b6e8f81e5df",
+    "wof:geomhash":"9f199f6766a6e4788dea2fd0451c3645",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -98,7 +99,7 @@
         }
     ],
     "wof:id":1108785281,
-    "wof:lastmodified":1566640327,
+    "wof:lastmodified":1695886319,
     "wof:name":"Riaba",
     "wof:parent_id":85671599,
     "wof:placetype":"county",

--- a/data/110/878/528/3/1108785283.geojson
+++ b/data/110/878/528/3/1108785283.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.001261,
-    "geom:area_square_m":15588799.52732,
+    "geom:area_square_m":15588752.500485,
     "geom:bbox":"5.602111,-1.461278,5.637084,-1.402111",
     "geom:latitude":-1.432286,
     "geom:longitude":5.621013,
@@ -240,9 +240,10 @@
         "hasc:id":"GQ.AN.AN",
         "wd:id":"Q3736616"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GQ",
     "wof:created":1481835990,
-    "wof:geomhash":"50eb4a52798ac67361f563e481da4fcb",
+    "wof:geomhash":"2c628ffbc6dce3a5149e8bbda9e7b993",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -252,7 +253,7 @@
         }
     ],
     "wof:id":1108785283,
-    "wof:lastmodified":1690924040,
+    "wof:lastmodified":1695886089,
     "wof:name":"Annobon",
     "wof:parent_id":85671563,
     "wof:placetype":"county",

--- a/data/856/322/87/85632287.geojson
+++ b/data/856/322/87/85632287.geojson
@@ -1192,6 +1192,7 @@
         "hasc:id":"GQ",
         "icao:code":"3C",
         "ioc:id":"GEQ",
+        "iso:code":"GQ",
         "itu:id":"GNE",
         "loc:id":"n82047828",
         "m49:code":"226",
@@ -1206,6 +1207,7 @@
         "wk:page":"Equatorial Guinea",
         "wmo:id":"GQ"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"GQ",
     "wof:country_alpha3":"GNQ",
     "wof:geom_alt":[
@@ -1229,7 +1231,7 @@
         "spa",
         "fra"
     ],
-    "wof:lastmodified":1694639558,
+    "wof:lastmodified":1695881217,
     "wof:name":"Equatorial Guinea",
     "wof:parent_id":102191573,
     "wof:placetype":"country",

--- a/data/856/715/63/85671563.geojson
+++ b/data/856/715/63/85671563.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.001261,
-    "geom:area_square_m":15588799.52732,
+    "geom:area_square_m":15588752.500485,
     "geom:bbox":"5.602111,-1.461278,5.637084,-1.402111",
     "geom:latitude":-1.432286,
     "geom:longitude":5.621013,
@@ -303,17 +303,19 @@
         "gn:id":2310307,
         "gp:id":20069854,
         "hasc:id":"GQ.AN",
+        "iso:code":"GQ-AN",
         "iso:id":"GQ-AN",
         "qs_pg:id":1149769,
         "unlc:id":"GQ-AN",
         "wd:id":"Q3736616",
         "wk:page":"Annob\u00f3n Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"GQ",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"50eb4a52798ac67361f563e481da4fcb",
+    "wof:geomhash":"2c628ffbc6dce3a5149e8bbda9e7b993",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -330,7 +332,7 @@
         "spa",
         "fra"
     ],
-    "wof:lastmodified":1690924037,
+    "wof:lastmodified":1695884367,
     "wof:name":"Annob\u00f3n",
     "wof:parent_id":85632287,
     "wof:placetype":"region",

--- a/data/856/715/65/85671565.geojson
+++ b/data/856/715/65/85671565.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.671694,
-    "geom:area_square_m":8302505341.719349,
+    "geom:area_square_m":8302504902.964447,
     "geom:bbox":"9.980085,1.0,10.976151,2.172222",
     "geom:latitude":1.534665,
     "geom:longitude":10.397572,
@@ -288,17 +288,19 @@
         "gn:id":2566980,
         "gp:id":20069850,
         "hasc:id":"GQ.CS",
+        "iso:code":"GQ-CS",
         "iso:id":"GQ-CS",
         "qs_pg:id":223305,
         "unlc:id":"GQ-CS",
         "wd:id":"Q845823",
         "wk:page":"Centro Sur Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"GQ",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"7a794a4d4a1f55cf4df36ffb530cf4ae",
+    "wof:geomhash":"f42c3da95c2919d5e8d458aef6369130",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -315,7 +317,7 @@
         "spa",
         "fra"
     ],
-    "wof:lastmodified":1690924036,
+    "wof:lastmodified":1695884947,
     "wof:name":"Centro Sur",
     "wof:parent_id":85632287,
     "wof:placetype":"region",

--- a/data/856/715/83/85671583.geojson
+++ b/data/856/715/83/85671583.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.251583,
-    "geom:area_square_m":3108958961.390953,
+    "geom:area_square_m":3108958873.600723,
     "geom:bbox":"10.380148,1.755108,11.3333,2.172222",
     "geom:latitude":2.009657,
     "geom:longitude":10.96241,
@@ -276,17 +276,19 @@
         "gn:id":2566981,
         "gp:id":20069851,
         "hasc:id":"GQ.KN",
+        "iso:code":"GQ-KN",
         "iso:id":"GQ-KN",
         "qs_pg:id":955192,
         "unlc:id":"GQ-KN",
         "wd:id":"Q853393",
         "wk:page":"Ki\u00e9-Ntem Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"GQ",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"2efaa76354465085efbce6eaacde9ad7",
+    "wof:geomhash":"54dcfd3cc3025735ad122bfdd139e9b9",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -303,7 +305,7 @@
         "spa",
         "fra"
     ],
-    "wof:lastmodified":1690924038,
+    "wof:lastmodified":1695884367,
     "wof:name":"Ki\u00e9-Ntem",
     "wof:parent_id":85632287,
     "wof:placetype":"region",

--- a/data/856/715/89/85671589.geojson
+++ b/data/856/715/89/85671589.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.575996,
-    "geom:area_square_m":7119834398.610514,
+    "geom:area_square_m":7119833965.318253,
     "geom:bbox":"9.30375,0.886222,10.261504,2.343722",
     "geom:latitude":1.473501,
     "geom:longitude":9.839208,
@@ -289,17 +289,19 @@
         "gn:id":2566982,
         "gp:id":20069853,
         "hasc:id":"GQ.LI",
+        "iso:code":"GQ-LI",
         "iso:id":"GQ-LI",
         "qs_pg:id":891632,
         "unlc:id":"GQ-LI",
         "wd:id":"Q203873",
         "wk:page":"Litoral Province (Equatorial Guinea)"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"GQ",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"6b697e083122dae469bf4076416dc54d",
+    "wof:geomhash":"454f94d5b5940ca0b44edf6fe16a0bb3",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -316,7 +318,7 @@
         "spa",
         "fra"
     ],
-    "wof:lastmodified":1690924035,
+    "wof:lastmodified":1695884947,
     "wof:name":"Litoral",
     "wof:parent_id":85632287,
     "wof:placetype":"region",

--- a/data/856/715/91/85671591.geojson
+++ b/data/856/715/91/85671591.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.529932,
-    "geom:area_square_m":6550408022.935796,
+    "geom:area_square_m":6550408419.339255,
     "geom:bbox":"10.529065,1.0,11.3333,2.021691",
     "geom:latitude":1.497073,
     "geom:longitude":10.989528,
@@ -271,17 +271,19 @@
         "gn:id":2566983,
         "gp:id":20069852,
         "hasc:id":"GQ.WE",
+        "iso:code":"GQ-WN",
         "iso:id":"GQ-WN",
         "qs_pg:id":1149768,
         "unlc:id":"GQ-WN",
         "wd:id":"Q853400",
         "wk:page":"Wele-Nzas Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"GQ",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"479b9393461b13329442e75ebca38eed",
+    "wof:geomhash":"f2a2b9aeff6e73c78ca34d69bb67d550",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -298,7 +300,7 @@
         "spa",
         "fra"
     ],
-    "wof:lastmodified":1690924036,
+    "wof:lastmodified":1695884367,
     "wof:name":"Wele-Nz\u00e1s",
     "wof:parent_id":85632287,
     "wof:placetype":"region",

--- a/data/856/715/95/85671595.geojson
+++ b/data/856/715/95/85671595.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.054986,
-    "geom:area_square_m":678520738.924028,
+    "geom:area_square_m":678520932.79636,
     "geom:bbox":"8.609694,3.528311,8.940444,3.787055",
     "geom:latitude":3.662793,
     "geom:longitude":8.784008,
@@ -287,17 +287,19 @@
         "gn:id":2566978,
         "gp:id":20069855,
         "hasc:id":"GQ.BS",
+        "iso:code":"GQ-BS",
         "iso:id":"GQ-BS",
         "qs_pg:id":1287551,
         "unlc:id":"GQ-BN",
         "wd:id":"Q845834",
         "wk:page":"Bioko Norte Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"GQ",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"b7f5563d41d15dc004387c1f59c1ae4a",
+    "wof:geomhash":"d678dd82f39d1760fb32c252f53ad762",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -314,7 +316,7 @@
         "spa",
         "fra"
     ],
-    "wof:lastmodified":1690924035,
+    "wof:lastmodified":1695884947,
     "wof:name":"Bioko Norte",
     "wof:parent_id":85632287,
     "wof:placetype":"region",

--- a/data/856/715/99/85671599.geojson
+++ b/data/856/715/99/85671599.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.103573,
-    "geom:area_square_m":1278436891.194133,
+    "geom:area_square_m":1278437219.534002,
     "geom:bbox":"8.419528,3.207917,8.857889,3.614304",
     "geom:latitude":3.404322,
     "geom:longitude":8.635288,
@@ -287,17 +287,19 @@
         "gn:id":2566979,
         "gp:id":20069856,
         "hasc:id":"GQ.BN",
+        "iso:code":"GQ-BN",
         "iso:id":"GQ-BN",
         "qs_pg:id":1118433,
         "unlc:id":"GQ-BS",
         "wd:id":"Q845817",
         "wk:page":"Bioko Sur Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"GQ",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"ecf8beafeadb1bba41b14a593fad716c",
+    "wof:geomhash":"ae16d754ace1d1d5027da3e4b12b35e8",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -314,7 +316,7 @@
         "spa",
         "fra"
     ],
-    "wof:lastmodified":1690924037,
+    "wof:lastmodified":1695884947,
     "wof:name":"Bioko Sur",
     "wof:parent_id":85632287,
     "wof:placetype":"region",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2164. Sets wof:concordances_official, wof:concordances_official_alt, and wof:label_*_x_preferred properties, and wof:concordances{*:*} hashes when approprirate.